### PR TITLE
Remove Prometheus rules for rook storage

### DIFF
--- a/cluster/core/rook-ceph/storage/helm-release.yaml
+++ b/cluster/core/rook-ceph/storage/helm-release.yaml
@@ -29,7 +29,6 @@ spec:
   values:
     monitoring:
       enabled: true
-      createPrometheusRules: true
     ingress:
       dashboard:
         annotations:


### PR DESCRIPTION
Because they are very noisy and loud
