### PR TITLE
Update cloudflared image to 2022.10.0-amd64

### DIFF
--- a/cluster/apps/networking/cloudflared/helm-release.yaml
+++ b/cluster/apps/networking/cloudflared/helm-release.yaml
@@ -20,7 +20,7 @@ spec:
       nameOverride: cloudflared
     image:
       repository: cloudflare/cloudflared
-      tag: 2022.8.0
+      tag: 2022.10.0-amd64
     args:
       - tunnel
       - --config


### PR DESCRIPTION
Update cloudflared image to 2022.10.0-amd64 and secretly hope Renovate picks up on future ones
