### PR TITLE
Revert "fix(container): update quay.io/ceph/ceph ( v19.2.1 → v19.2.2 )"

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
           bdev_async_discard_threads: "1"
           osd_class_update_on_start: "false"
       cephVersion:
-        image: quay.io/ceph/ceph:v19.2.2
+        image: quay.io/ceph/ceph:v19.2.1
       crashCollector:
         disable: false
       dashboard:


### PR DESCRIPTION
Reverts woll0r/k8s-cluster#3630

Ceph image v19.2.2 was pulled