### PR TITLE
fix(rook-ceph): rotate daemon keys for CVE-2025–30156

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -79,6 +79,11 @@ spec:
           - name: kube-05
             devices:
               - name: /dev/disk/by-id/nvme-CT1000P3PSSD8_2414486566F0
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
       resources:
         mgr:
           requests:


### PR DESCRIPTION
New Rook and Ceph versions check for [CVE-2025-30156](https://docs.ceph.com/en/latest/security/CVE-2025-30156/).

Sets the `keyRotationPolicy: KeyGeneration` and `keyGeneration: 2` in `spec.security.cephx.daemon` to force key rotation and resolve the issue.

Fix from [Rook CephX Keys and Rotation](https://rook.io/docs/rook/v1.20/Storage-Configuration/Advanced/cephx-key-rotation/#quick-resolution-guide)
