### PR TITLE
fix(rook-ceph): Mute health checks due to key types

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -79,6 +79,18 @@ spec:
           - name: kube-05
             devices:
               - name: /dev/disk/by-id/nvme-CT1000P3PSSD8_2414486566F0
+      healthCheck:
+        # TODO: set policy to `unmute` once Talos goes to kernel 7.0+
+        # Mute is permanent until explicitly unmuted!
+        muteHealthWarning:
+          AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_CLIENT_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_KEYS_ALLOWED:
+            policy: mute
+          AUTH_INSECURE_KEYS_CREATABLE:
+            policy: mute
       security:
         cephx:
           daemon:


### PR DESCRIPTION
With the fix for CVE-2025-30156, there are still warnings left for "insecure" keys.

AES256K CSI keys require kernel version 7.0+, but Talos uses the 6.18 LTS kernel. So the warnings for insecure keys are muted until the kernel is updated to something 7.0+.

See docs: [Rook CephX Keys and Rotation](https://rook.io/docs/rook/v1.20/Storage-Configuration/Advanced/cephx-key-rotation/)
